### PR TITLE
refactor: use fspath for CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     types:
       - published
 
+env:
+  FORCE_COLOR: 3
+
 jobs:
   pre-commit:
     name: Format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black-jupyter
 
@@ -32,7 +32,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.7.1"
+    rev: "v3.0.0-alpha.0"
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
@@ -42,7 +42,7 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.3.0]
+        additional_dependencies: [black==22.8.0]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
@@ -60,7 +60,6 @@ repos:
     rev: v2.1.1
     hooks:
       - id: pycln
-        additional_dependencies: [click<8.1]
         args: [--all]
         stages: [manual]
 
@@ -90,7 +89,7 @@ repos:
           - packaging
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.0
+    rev: v2.2.1
     hooks:
       - id: codespell
         exclude: ^LICENSE$

--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -45,7 +45,9 @@ class Run:
         kw_options = [
             item for key, value in kwargs.items() for item in (f"--{key}", f"{value}")
         ]
-        options = [f"{arg}" for arg in args] + kw_options
+        options = [
+            os.fspath(arg) if isinstance(arg, os.PathLike) else arg for arg in args
+        ] + kw_options
 
         logger.debug("RUN: {}", " ".join(options))
 

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -31,8 +32,10 @@ def test_init_cache(fp, tmp_path):
         f"-S{config.source_dir}",
         f"-B{config.build_dir}",
         f"-C{cmake_init}",
-        "-GNinja",
     ]
+    if not sys.platform.startswith("win32"):
+        cmd.append("-GNinja")
+
     print("Registering: ", *cmd)
     fp.register(cmd)
     config.configure()

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -9,9 +9,12 @@ from scikit_build_core.errors import CMakeConfigError
 
 DIR = Path(__file__).parent.absolute()
 
+# Due to https://github.com/scikit-build/cmake-python-distributions/pull/279
+# this is outside of the functions for now.
+cmake_path = get_cmake_path()
+
 
 def test_init_cache(fp, tmp_path):
-    cmake_path = get_cmake_path()
     fp.register([str(cmake_path), "--version"], stdout="3.14.0")
 
     config = CMakeConfig(
@@ -44,7 +47,6 @@ set(SKBUILD_PATH "{config.source_dir}" CACHE PATH "")
 
 
 def test_too_old(fp):
-    cmake_path = get_cmake_path()
     fp.register([str(cmake_path), "--version"], stdout="3.14.0")
 
     with pytest.raises(CMakeConfigError) as excinfo:
@@ -56,7 +58,6 @@ def test_too_old(fp):
 
 
 def test_cmake_args(tmp_path, fp):
-    cmake_path = get_cmake_path()
     fp.register([str(cmake_path), "--version"], stdout="3.15.0")
 
     config = CMakeConfig(

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -15,7 +16,7 @@ cmake_path = get_cmake_path()
 
 
 def test_init_cache(fp, tmp_path):
-    fp.register([str(cmake_path), "--version"], stdout="3.14.0")
+    fp.register([os.fspath(cmake_path), "--version"], stdout="3.14.0")
 
     config = CMakeConfig(
         CMake(), source_dir=DIR / "simple_pure", build_dir=tmp_path / "build"
@@ -25,15 +26,15 @@ def test_init_cache(fp, tmp_path):
     )
 
     cmake_init = config.build_dir / "CMakeInit.txt"
-    fp.register(
-        [
-            f"{cmake_path}",
-            f"-S{config.source_dir}",
-            f"-B{config.build_dir}",
-            f"-C{cmake_init}",
-            "-GNinja",
-        ]
-    )
+    cmd = [
+        os.fspath(cmake_path),
+        f"-S{config.source_dir}",
+        f"-B{config.build_dir}",
+        f"-C{cmake_init}",
+        "-GNinja",
+    ]
+    print("Registering: ", *cmd)
+    fp.register(cmd)
     config.configure()
 
     assert (
@@ -47,7 +48,7 @@ set(SKBUILD_PATH "{config.source_dir}" CACHE PATH "")
 
 
 def test_too_old(fp):
-    fp.register([str(cmake_path), "--version"], stdout="3.14.0")
+    fp.register([os.fspath(cmake_path), "--version"], stdout="3.14.0")
 
     with pytest.raises(CMakeConfigError) as excinfo:
         CMake(minimum_version="3.15")
@@ -58,7 +59,7 @@ def test_too_old(fp):
 
 
 def test_cmake_args(tmp_path, fp):
-    fp.register([str(cmake_path), "--version"], stdout="3.15.0")
+    fp.register([os.fspath(cmake_path), "--version"], stdout="3.15.0")
 
     config = CMakeConfig(
         CMake(), source_dir=DIR / "simple_pure", build_dir=tmp_path / "build"
@@ -66,7 +67,7 @@ def test_cmake_args(tmp_path, fp):
 
     fp.register(
         [
-            f"{cmake_path}",
+            os.fspath(cmake_path),
             f"-S{config.source_dir}",
             f"-B{config.build_dir}",
             "-GNinja",


### PR DESCRIPTION
- chore: updates pre-commit checks
- refactor: use `__fspath__` for cmake path
