### PR TITLE
chore: minor fix to coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package
-        run: python -m pip install .[test] pytest-cov
+        run: python -m pip install .[test,cov]
 
       - name: Test package
         run: python -m pytest -ra --showlocals --cov=scikit_build_core

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,7 +44,7 @@ def coverage(session: nox.Session) -> None:
     Run coverage and report.
     """
 
-    session.install("-e.[test]", "pytest-cov")
+    session.install("-e.[test,cov]")
     session.run("pytest", "--cov=scikit_build_core", *session.posargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ test = [
     "pytest >=7",
     "pytest-subprocess",
 ]
+cov = [
+    "pytest-cov[toml]",
+]
 dev = [
     "cattrs >=22.2.0",
     "pytest >=7",
@@ -109,4 +112,11 @@ messages_control.disable = [
   "wrong-import-position",
   "unnecessary-ellipsis",  # Conflicts with Protocols
   "broad-except",
+]
+
+
+[tool.coverage]
+report.exclude_lines = [
+  "pragma: no cover",
+  '\.\.\.',
 ]

--- a/tests/test_module_dir.py
+++ b/tests/test_module_dir.py
@@ -33,7 +33,11 @@ def test_all_modules_filter_all():
     for name in all_modules:
         module = importlib.import_module(name)
 
-        dir_module = set(dir(module))
+        try:
+            dir_module = set(dir(module))
+        except Exception:
+            print(f"dir() failed on {name}")
+            raise
         items = ["annotations", "os", "sys"]
         for item in items:
             assert item not in dir_module, f"{module.__file__} has {item!r}"


### PR DESCRIPTION
- chore: ignore protocols when computing coverage
- tests: print failed module if `__dir__` does not work
