### PR TITLE
feat: setuptools extension backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,7 @@ repos:
           - ninja
           - packaging
           - rich
+          - types-setuptools
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,20 +37,24 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+    "build",
     "cattrs >=22.2.0",
     "cmake >=3.15",
     "ninja",
     "pytest >=7",
     "pytest-subprocess",
+    "pytest-virtualenv",
     "rich",
 ]
 cov = [
     "pytest-cov[toml]",
 ]
 dev = [
+    "build",
     "cattrs >=22.2.0",
     "pytest >=7",
     "pytest-subprocess",
+    "pytest-virtualenv",
     "rich",
 ]
 docs = [
@@ -78,6 +82,7 @@ testpaths = ["tests"]
 markers = [
     "compile: Compiles code",
     "configure: Configures CMake code",
+    "integration: Full package build",
 ]
 
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Mapping
+
+from packaging.version import Version
+
+from scikit_build_core.settings.cmake_model import ScikitBuildSettings
+
+from .._logging import logger
+from ..builder.macos import get_macosx_deployment_target
+from ..builder.sysconfig import get_python_include_dir, get_python_library
+from ..cmake import CMakeConfig
+from ..errors import NinjaNotFoundError
+from ..program_search import best_program, get_ninja_programs
+
+__all__: list[str] = ["Builder"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@dataclasses.dataclass
+class Builder:
+    settings: ScikitBuildSettings
+    config: CMakeConfig
+
+    def configure(self, *, defines: Mapping[str, str], ext_dir: Path) -> None:
+        cmake_defines = dict(defines)
+
+        # Ninja is currently required on Unix
+        if not sys.platform.startswith("win32"):
+            ninja = best_program(
+                get_ninja_programs(),
+                minimum_version=Version(self.settings.ninja.minimum_version),
+            )
+            if ninja is None:
+                raise NinjaNotFoundError("Ninja is required to build")
+            self.config.env.setdefault("CMAKE_MAKE_PROGRAM", str(ninja.path))
+
+        cache_config: dict[str, str | Path] = {
+            "CMAKE_LIBRARY_OUTPUT_DIRECTORY": f"{ext_dir}{os.path.sep}",
+            "SKBUILD": "2",
+        }
+        if sys.platform.startswith("win32"):
+            cache_config[
+                f"CMAKE_LIBRARY_OUTPUT_DIRECTORY_{self.config.build_type.upper()}"
+            ] = f"{ext_dir}{os.path.sep}"
+
+        # Classic Find Python
+        python_library = get_python_library()
+        python_include_dir = get_python_include_dir()
+        cache_config["PYTHON_EXECUTABLE"] = sys.executable
+        cache_config["PYTHON_INCLUDE_DIR"] = python_include_dir
+        if python_library:
+            cache_config["PYTHON_LIBRARY"] = python_library
+
+        # Modern Find Python
+        for prefix in ["Python", "Python3"]:
+            cache_config[f"{prefix}_EXECUTABLE"] = sys.executable
+            cache_config[f"{prefix}_ROOT_DIR"] = sys.prefix
+            cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
+
+        self.config.init_cache(cache_config)
+
+        # Adding CMake arguments set as environment variable
+        # (needed e.g. to build for ARM OSX on conda-forge)
+        cmake_args = [
+            item for item in self.config.env.get("CMAKE_ARGS", "").split(" ") if item
+        ]
+
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", self.config.env.get("ARCHFLAGS", ""))
+            if archs:
+                cmake_defines["CMAKE_OSX_ARCHITECTURES"] = ";".join(archs)
+
+            self.config.env.setdefault(
+                "MACOSX_DEPLOYMENT_TARGET", get_macosx_deployment_target()
+            )
+            logger.info(
+                "MACOSX_DEPLOYMENT_TARGET is {}",
+                self.config.env["MACOSX_DEPLOYMENT_TARGET"],
+            )
+
+        self.config.configure(
+            defines=cmake_defines,
+            cmake_args=cmake_args,
+        )
+
+    def build(self, build_args: list[str]) -> None:
+        # TODO: configure verbose
+        self.config.build(build_args=build_args, verbose=1)
+
+    def install(self, install_dir: Path) -> None:
+        self.config.install(install_dir)

--- a/src/scikit_build_core/setuptools/__init__.py
+++ b/src/scikit_build_core/setuptools/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/scikit_build_core/setuptools/build_meta.py
+++ b/src/scikit_build_core/setuptools/build_meta.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from scikit_build_core.get_requires import (
+    get_requires_for_build_wheel as skbuild_get_requires_for_build_wheel,
+)
+
+__all__ = [
+    "prepare_metadata_for_build_wheel",
+    "build_wheel",
+    "build_sdist",
+    "get_requires_for_build_sdist",
+    "get_requires_for_build_wheel",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def get_requires_for_build_sdist(
+    # pylint: disable-next=unused-argument
+    config_settings: dict[str, str | list[str]]
+    | None = None
+) -> list[str]:
+    return ["setuptools"]
+
+
+def get_requires_for_build_wheel(
+    config_settings: dict[str, str | list[str]] | None = None
+) -> list[str]:
+    return ["setuptools", "wheel"] + skbuild_get_requires_for_build_wheel(
+        config_settings
+    )
+
+
+def build_sdist(
+    sdist_directory: str,
+    config_settings: dict[str, str | list[str]] | None = None,
+) -> None:
+    import setuptools.build_meta
+
+    setuptools.build_meta.build_sdist(sdist_directory, config_settings)
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: dict[str, str | list[str]] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    import setuptools.build_meta
+
+    return setuptools.build_meta.build_wheel(  # type: ignore[no-any-return]
+        wheel_directory, config_settings, metadata_directory
+    )
+
+
+def prepare_metadata_for_build_wheel(
+    metadata_directory: str,
+    config_settings: dict[str, str | list[str]] | None = None,
+) -> str:
+    import setuptools.build_meta
+
+    return setuptools.build_meta.prepare_metadata_for_build_wheel(  # type: ignore[no-any-return]
+        metadata_directory, config_settings
+    )

--- a/src/scikit_build_core/setuptools/extension.py
+++ b/src/scikit_build_core/setuptools/extension.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
 
 import os
-import re
 import shutil
-import sys
 from pathlib import Path
 
 import setuptools
 import setuptools.command.build_ext
 from packaging.version import Version
 
-from .._logging import logger
-from ..builder.macos import get_macosx_deployment_target
-from ..builder.sysconfig import get_python_include_dir, get_python_library
+from ..builder.builder import Builder
 from ..cmake import CMake, CMakeConfig
-from ..errors import NinjaNotFoundError
-from ..program_search import best_program, get_ninja_programs
 from ..settings.skbuild_settings import read_settings
 
 __all__: list[str] = ["CMakeExtension"]
@@ -49,20 +43,20 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
             super().build_extension(ext)
             return
 
-        settings = read_settings(Path("pyproject.toml"), {})
+        build_tmp_folder = Path(self.build_temp)
+        install_dir = build_tmp_folder / ext.name
+        build_temp = build_tmp_folder / "_skbuild"  # TODO: include python platform
 
         # This dir doesn't exist, so Path.cwd() is needed for Python < 3.10
         # due to a Windows bug in resolve https://github.com/python/cpython/issues/82852
         ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)  # type: ignore[no-untyped-call]
         extdir = ext_fullpath.parent.resolve()
 
-        build_tmp_folder = Path(self.build_temp)
-        install_dir = build_tmp_folder / ext.name
-        build_temp = build_tmp_folder / "_skbuild"  # TODO: include python platform
-
         # TODO: this is a hack due to moving temporary paths for isolation
         if build_temp.exists():
             shutil.rmtree(build_temp)
+
+        settings = read_settings(Path("pyproject.toml"), {})
 
         cmake = CMake.default_search(
             minimum_version=Version(settings.cmake.minimum_version)
@@ -73,83 +67,30 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
             build_dir=build_temp,
         )
 
+        builder = Builder(
+            settings=settings,
+            config=config,
+        )
+
         debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
-        config.build_type = "Debug" if debug else "Release"
+        builder.config.build_type = "Debug" if debug else "Release"
 
-        # Ninja is currently required on Unix
-        if not sys.platform.startswith("win32"):
-            ninja = best_program(
-                get_ninja_programs(),
-                minimum_version=Version(settings.ninja.minimum_version),
-            )
-            if ninja is None:
-                raise NinjaNotFoundError("Ninja is required to build")
-            config.env.setdefault("CMAKE_MAKE_PROGRAM", str(ninja.path))
-
-        cache_config: dict[str, str | Path] = {
-            "CMAKE_LIBRARY_OUTPUT_DIRECTORY": f"{extdir}{os.path.sep}",
-            "SKBUILD": "2",
-        }
-        if sys.platform.startswith("win32"):
-            cache_config[
-                f"CMAKE_LIBRARY_OUTPUT_DIRECTORY_{config.build_type.upper()}"
-            ] = f"{extdir}{os.path.sep}"
-
-        # Classic Find Python
-        python_library = get_python_library()
-        python_include_dir = get_python_include_dir()
-        cache_config["PYTHON_EXECUTABLE"] = sys.executable
-        cache_config["PYTHON_INCLUDE_DIR"] = python_include_dir
-        if python_library:
-            cache_config["PYTHON_LIBRARY"] = python_library
-
-        # Modern Find Python
-        for prefix in ["Python", "Python3"]:
-            cache_config[f"{prefix}_EXECUTABLE"] = sys.executable
-            cache_config[f"{prefix}_ROOT_DIR"] = sys.prefix
-            cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
-
-        config.init_cache(cache_config)
-
-        # Adding CMake arguments set as environment variable
-        # (needed e.g. to build for ARM OSX on conda-forge)
-        cmake_args = [
-            item for item in config.env.get("CMAKE_ARGS", "").split(" ") if item
-        ]
         defines: dict[str, str] = {}
-
-        if sys.platform.startswith("darwin"):
-            # Cross-compile support for macOS - respect ARCHFLAGS if set
-            archs = re.findall(r"-arch (\S+)", config.env.get("ARCHFLAGS", ""))
-            if archs:
-                defines["CMAKE_OSX_ARCHITECTURES"] = ";".join(archs)
-
-            config.env.setdefault(
-                "MACOSX_DEPLOYMENT_TARGET", get_macosx_deployment_target()
-            )
-            logger.info(
-                "MACOSX_DEPLOYMENT_TARGET is {}", config.env["MACOSX_DEPLOYMENT_TARGET"]
-            )
 
         for key, value in ext.define_macros:
             assert isinstance(value, str), "define_macros values must not be None"
             defines[key] = value
 
-        config.configure(
-            defines=defines,
-            cmake_args=cmake_args,
-        )
+        builder.configure(defines=defines, ext_dir=extdir)
 
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.
         build_args = []
-        if "CMAKE_BUILD_PARALLEL_LEVEL" not in config.env:
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in builder.config.env:
             # self.parallel is a Python 3 only way to set parallel jobs by hand
             # using -j in the build_ext call, not supported by pip or PyPA-build.
             if hasattr(self, "parallel") and self.parallel:
                 build_args.append(f"-j{self.parallel}")
 
-        # TODO: configure verbose
-        config.build(build_args=build_args, verbose=1)
-
-        config.install(install_dir)
+        builder.build(build_args=build_args)
+        builder.install(install_dir)

--- a/src/scikit_build_core/setuptools/extension.py
+++ b/src/scikit_build_core/setuptools/extension.py
@@ -95,19 +95,24 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
                 f"CMAKE_LIBRARY_OUTPUT_DIRECTORY_{config.build_type.upper()}"
             ] = f"{extdir}{os.path.sep}"
 
+        # Classic Find Python
         python_library = get_python_library()
         python_include_dir = get_python_include_dir()
+        cache_config["PYTHON_EXECUTABLE"] = sys.executable
+        cache_config["PYTHON_INCLUDE_DIR"] = python_include_dir
+        if python_library:
+            cache_config["PYTHON_LIBRARY"] = python_library
 
-        for prefix in ["Python", "Python3", "PYTHON"]:
+        # Modern Find Python
+        for prefix in ["Python", "Python3"]:
             cache_config[f"{prefix}_EXECUTABLE"] = sys.executable
-            cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
-            if python_library:
-                cache_config[f"{prefix}_LIBRARY"] = python_library
+            cache_config[f"{prefix}_ROOT_DIR"] = sys.prefix
+            cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
 
         config.init_cache(cache_config)
 
         # Adding CMake arguments set as environment variable
-        # (needed e.g. to build for ARM OSx on conda-forge)
+        # (needed e.g. to build for ARM OSX on conda-forge)
         cmake_args = [
             item for item in config.env.get("CMAKE_ARGS", "").split(" ") if item
         ]

--- a/src/scikit_build_core/setuptools/extension.py
+++ b/src/scikit_build_core/setuptools/extension.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import setuptools
+import setuptools.command.build_ext
+from packaging.version import Version
+
+from .._logging import logger
+from ..builder.macos import get_macosx_deployment_target
+from ..builder.sysconfig import get_python_include_dir, get_python_library
+from ..cmake import CMake, CMakeConfig
+from ..errors import NinjaNotFoundError
+from ..program_search import best_program, get_ninja_programs
+from ..settings.skbuild_settings import read_settings
+
+__all__: list[str] = ["CMakeExtension"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+# Convert distutils Windows platform specifiers to CMake -A arguments
+PLAT_TO_CMAKE = {
+    "win32": "Win32",
+    "win-amd64": "x64",
+    "win-arm32": "ARM",
+    "win-arm64": "ARM64",
+}
+
+
+# A CMakeExtension needs a sourcedir instead of a file list.
+# The name must be the _single_ output extension from the CMake build.
+# The sourcedir is relative to the setup.py directory, where the CMakeLists.txt lives
+class CMakeExtension(setuptools.Extension):
+    def __init__(self, name: str, sourcedir: str = "", **kwargs: object) -> None:
+        setuptools.Extension.__init__(self, name, sources=[], **kwargs)
+        self.sourcedir = Path(sourcedir).resolve()
+
+
+class CMakeBuild(setuptools.command.build_ext.build_ext):
+    def build_extension(self, ext: setuptools.Extension) -> None:
+        if not isinstance(ext, CMakeExtension):
+            super().build_extension(ext)
+            return
+
+        settings = read_settings(Path("pyproject.toml"), {})
+
+        # This dir doesn't exist, so Path.cwd() is needed for Python < 3.10
+        # due to a Windows bug in resolve https://github.com/python/cpython/issues/82852
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)  # type: ignore[no-untyped-call]
+        extdir = ext_fullpath.parent.resolve()
+
+        build_tmp_folder = Path(self.build_temp)
+        install_dir = build_tmp_folder / ext.name
+        build_temp = build_tmp_folder / "_skbuild"  # TODO: include python platform
+
+        # TODO: this is a hack due to moving temporary paths for isolation
+        if build_temp.exists():
+            shutil.rmtree(build_temp)
+
+        cmake = CMake.default_search(
+            minimum_version=Version(settings.cmake.minimum_version)
+        )
+        config = CMakeConfig(
+            cmake,
+            source_dir=ext.sourcedir,
+            build_dir=build_temp,
+        )
+
+        debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
+        config.build_type = "Debug" if debug else "Release"
+
+        # Ninja is currently required on Unix
+        if not sys.platform.startswith("win32"):
+            ninja = best_program(
+                get_ninja_programs(),
+                minimum_version=Version(settings.ninja.minimum_version),
+            )
+            if ninja is None:
+                raise NinjaNotFoundError("Ninja is required to build")
+            config.env.setdefault("CMAKE_MAKE_PROGRAM", str(ninja.path))
+
+        cache_config: dict[str, str | Path] = {
+            "CMAKE_LIBRARY_OUTPUT_DIRECTORY": f"{extdir}{os.path.sep}",
+            "SKBUILD": "2",
+        }
+        if sys.platform.startswith("win32"):
+            cache_config[
+                f"CMAKE_LIBRARY_OUTPUT_DIRECTORY_{config.build_type.upper()}"
+            ] = f"{extdir}{os.path.sep}"
+
+        python_library = get_python_library()
+        python_include_dir = get_python_include_dir()
+
+        for prefix in ["Python", "Python3", "PYTHON"]:
+            cache_config[f"{prefix}_EXECUTABLE"] = sys.executable
+            cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
+            if python_library:
+                cache_config[f"{prefix}_LIBRARY"] = python_library
+
+        config.init_cache(cache_config)
+
+        # Adding CMake arguments set as environment variable
+        # (needed e.g. to build for ARM OSx on conda-forge)
+        cmake_args = [
+            item for item in config.env.get("CMAKE_ARGS", "").split(" ") if item
+        ]
+        defines: dict[str, str] = {}
+
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", config.env.get("ARCHFLAGS", ""))
+            if archs:
+                defines["CMAKE_OSX_ARCHITECTURES"] = ";".join(archs)
+
+            config.env.setdefault(
+                "MACOSX_DEPLOYMENT_TARGET", get_macosx_deployment_target()
+            )
+            logger.info(
+                "MACOSX_DEPLOYMENT_TARGET is {}", config.env["MACOSX_DEPLOYMENT_TARGET"]
+            )
+
+        for key, value in ext.define_macros:
+            assert isinstance(value, str), "define_macros values must not be None"
+            defines[key] = value
+
+        config.configure(
+            defines=defines,
+            cmake_args=cmake_args,
+        )
+
+        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
+        # across all generators.
+        build_args = []
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in config.env:
+            # self.parallel is a Python 3 only way to set parallel jobs by hand
+            # using -j in the build_ext call, not supported by pip or PyPA-build.
+            if hasattr(self, "parallel") and self.parallel:
+                build_args.append(f"-j{self.parallel}")
+
+        # TODO: configure verbose
+        config.build(build_args=build_args, verbose=1)
+
+        config.install(install_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,64 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+DIR = Path(__file__).parent.resolve()
+BASE = DIR.parent
+
+
+@pytest.fixture(scope="session")
+def pep518_wheelhouse(tmpdir_factory):
+    wheelhouse = tmpdir_factory.mktemp("wheelhouse")
+    dist = tmpdir_factory.mktemp("dist")
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist)],
+        cwd=str(BASE),
+        check=True,
+    )
+    (wheel_path,) = dist.visit("*.whl")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "download",
+            "-q",
+            "-d",
+            str(wheelhouse),
+            str(wheel_path),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "download",
+            "-q",
+            "-d",
+            str(wheelhouse),
+            "build",
+            "setuptools",
+            "wheel",
+            "ninja",
+            "pybind11",
+            "cmake",
+            "numpy",
+            "exceptiongroup",
+            "packaging",
+            "tomli",
+            "typing-extensions",
+        ],
+        check=True,
+    )
+    return str(wheelhouse)
+
+
+@pytest.fixture
+def pep518(pep518_wheelhouse, monkeypatch):
+    monkeypatch.setenv("PIP_FIND_LINKS", pep518_wheelhouse)
+    monkeypatch.setenv("PIP_NO_INDEX", "true")
+    return pep518_wheelhouse

--- a/tests/simple_setuptools_ext/CMakeLists.txt
+++ b/tests/simple_setuptools_ext/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.4...3.18)
+project(cmake_example)
+
+execute_process(
+COMMAND "${PYTHON_EXECUTABLE}" -c
+        "import pybind11; print(pybind11.get_cmake_dir())"
+OUTPUT_VARIABLE _tmp_dir
+OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
+list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+
+find_package(pybind11 CONFIG REQUIRED)
+pybind11_add_module(cmake_example src/main.cpp)
+
+# VERSION_INFO is defined by setup.py and passed into the C++ code as a
+# define (VERSION_INFO) here.
+target_compile_definitions(cmake_example
+                           PRIVATE VERSION_INFO=${VERSION_INFO})

--- a/tests/simple_setuptools_ext/pyproject.toml
+++ b/tests/simple_setuptools_ext/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "scikit_build_core",
+    "pybind11",
+]
+build-backend = "scikit_build_core.setuptools.build_meta"

--- a/tests/simple_setuptools_ext/setup.py
+++ b/tests/simple_setuptools_ext/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+from scikit_build_core.setuptools.extension import CMakeBuild, CMakeExtension
+
+setup(
+    name="cmake_example",
+    version="0.0.1",
+    ext_modules=[
+        CMakeExtension("cmake_example", define_macros=[("VERSION_INFO", "0.0.1")])
+    ],
+    zip_safe=False,
+    extras_require={"test": ["pytest>=6.0"]},
+    cmdclass={"build_ext": CMakeBuild},
+    python_requires=">=3.7",
+)

--- a/tests/simple_setuptools_ext/src/main.cpp
+++ b/tests/simple_setuptools_ext/src/main.cpp
@@ -1,0 +1,38 @@
+#include <pybind11/pybind11.h>
+
+#define STRINGIFY(x) #x
+#define MACRO_STRINGIFY(x) STRINGIFY(x)
+
+int add(int i, int j) {
+    return i + j;
+}
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(cmake_example, m) {
+    m.doc() = R"pbdoc(
+        Pybind11 example plugin
+        -----------------------
+        .. currentmodule:: cmake_example
+        .. autosummary::
+           :toctree: _generate
+           add
+           subtract
+    )pbdoc";
+
+    m.def("add", &add, R"pbdoc(
+        Add two numbers
+        Some other explanation about the add function.
+    )pbdoc");
+
+    m.def("subtract", [](int i, int j) { return i - j; }, R"pbdoc(
+        Subtract two numbers
+        Some other explanation about the subtract function.
+    )pbdoc");
+
+#ifdef VERSION_INFO
+    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+#else
+    m.attr("__version__") = "dev";
+#endif
+}

--- a/tests/test_setuptools_pep518.py
+++ b/tests/test_setuptools_pep518.py
@@ -1,0 +1,68 @@
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+DIR = Path(__file__).parent.resolve()
+HELLO_PEP518 = DIR / "simple_setuptools_ext"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.integration
+def test_pep518_wheel(pep518, virtualenv):
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel"], cwd=HELLO_PEP518, check=True
+    )
+    dist = HELLO_PEP518 / "dist"
+    (wheel,) = dist.iterdir()
+    assert "cmake_example-0.0.1" in wheel.name
+    assert wheel.suffix == ".whl"
+
+    if sys.version_info >= (3, 8):
+        with wheel.open("rb") as f:
+            p = zipfile.Path(f)
+            file_names = [p.name for p in p.iterdir()]
+
+        assert len(file_names) == 2
+        assert "cmake_example-0.0.1.dist-info" in file_names
+        file_names.remove("cmake_example-0.0.1.dist-info")
+        (so_file,) = file_names
+
+        assert so_file.startswith("cmake_example")
+        print("SOFILE:", so_file)
+
+    virtualenv.run(f"python -m pip install {wheel}")
+
+    version = virtualenv.run(
+        'python -c "import cmake_example; print(cmake_example.__version__)"',
+        capture=True,
+    )
+    assert version.strip() == "0.0.1"
+
+    add = virtualenv.run(
+        'python -c "import cmake_example; print(cmake_example.add(1, 2))"',
+        capture=True,
+    )
+    assert add.strip() == "3"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.integration
+def test_pep518_pip(pep518, virtualenv):
+    virtualenv.run(f"python -m pip install -v {HELLO_PEP518}")
+
+    version = virtualenv.run(
+        'python -c "import cmake_example; print(cmake_example.__version__)"',
+        capture=True,
+    )
+    assert version.strip() == "0.0.1"
+
+    add = virtualenv.run(
+        'python -c "import cmake_example; print(cmake_example.add(1, 2))"',
+        capture=True,
+    )
+    assert add.strip() == "3"


### PR DESCRIPTION
Implementing a setuptools backend based on pybind11's `cmake_example`.

Design features:

* `build_ext` must be added manually - setuptools overrides this already sadly, so we can't be assured we are first if we add it as an entrypoint.
* Vanilla `setuptools.setup` - could be wrapped to automatically add setup.
* Dependencies are declared dynamically when using the PEP 517 builder

A few things to do (after this PR):

* Caching doesn't work (PEP 517's environments break paths).
* Still no nice way to declare a module
* No internal modules yet like Python helpers
* No support for editable installs
* Only a single output module supported at the moment.

Todo in this PR:
- [x] Fix windows
- [x] Test produced binary (pytest-virtualenv, probably)