### PR TITLE
feat: starting builder helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,10 +106,10 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
-.venv
-env/
-venv/
+.env*
+.venv*
+env*/
+venv*/
 ENV/
 env.bak/
 venv.bak/
@@ -140,3 +140,6 @@ cython_debug/
 
 # setuptools_scm
 src/*/_version.py
+
+# SKBuild cache dir
+_skbuild/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: ["--pytest-test-first"]
+        exclude: "^tests/simple"
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         exclude: "^tests"

--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -26,6 +26,11 @@ class FStringMessage:
     def __str__(self) -> str:
         return self.fmt.format(*self.args, **self.kwargs)
 
+    def __repr__(self) -> str:
+        return (
+            f"<FStringMessage {self.fmt!r} args={self.args!r} kwargs={self.kwargs!r}>"
+        )
+
 
 class ScikitBuildLogger:
     # pylint: disable-next=redefined-outer-name

--- a/src/scikit_build_core/builder/__init__.py
+++ b/src/scikit_build_core/builder/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+import platform
+
+__all__ = ["get_macosx_deployment_target"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def normalize_macos_version(version: str) -> str:
+    """
+    Set minor version to 0 if major is 11+.
+    """
+    major, minor = version.split(".")[0:2]
+    minor = "0" if int(major) >= 11 else minor
+    return f"{major}.{minor}"
+
+
+def get_macosx_deployment_target() -> str:
+    """
+    Get the MACOSX_DEPLOYMENT_TARGET environment variable or use the version
+    Python was built with. Suggestion: do not touch MACOSX_DEPLOYMENT_TARGET
+    if it's set.
+    """
+    target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", None)
+    plat_target = normalize_macos_version(platform.mac_ver()[0])
+    if target is None:
+        return plat_target
+
+    env_target = ".".join(target.split(".")[:2]) if "." in target else f"{target}.0"
+    try:
+        float(env_target)
+    except ValueError:
+        return plat_target
+
+    norm_env_target = normalize_macos_version(env_target)
+    return (
+        norm_env_target if float(norm_env_target) > float(plat_target) else plat_target
+    )

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -108,11 +108,16 @@ class CMakeConfig:
             for key, value in cache_settings.items():
                 if isinstance(value, bool):
                     value = "ON" if value else "OFF"
-                    f.write(f'set({key} "{value}" CACHE BOOL "")\n')
+                    f.write(f'set({key} {value} CACHE BOOL "")\n')
                 elif isinstance(value, os.PathLike):
-                    f.write(f'set({key} "{value}" CACHE PATH "")\n')
+                    f.write(f'set({key} [===[{value}]===] CACHE PATH "")\n')
                 else:
-                    f.write(f'set({key} "{value}" CACHE STRING "")\n')
+                    f.write(f'set({key} [===[{value}]===] CACHE STRING "")\n')
+        logger.debug(
+            "{}:\n{}",
+            self.init_cache_file,
+            self.init_cache_file.read_text(encoding="utf-8"),
+        )
 
     def _compute_cmake_args(
         self, settings: Mapping[str, str | os.PathLike[str] | bool]

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -95,7 +95,7 @@ class CMakeConfig:
         if not self.source_dir.is_dir():
             raise CMakeConfigError(f"source directory {self.source_dir} does not exist")
 
-        self.build_dir.mkdir(parents=True, exist_ok=False)
+        self.build_dir.mkdir(parents=True, exist_ok=True)
         if not self.build_dir.is_dir():
             raise CMakeConfigError(
                 f"build directory {self.build} must be a (creatable) directory"

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import os
 import pathlib
@@ -33,12 +34,10 @@ def get_cmake_path(*, module: bool = True) -> Path:
     Get the path to CMake.
     """
     if module:
-        try:
+        with contextlib.suppress(ImportError):
             import cmake
 
             return pathlib.Path(cmake.CMAKE_BIN_DIR) / "cmake"
-        except ImportError:
-            pass
 
     cmake_path = shutil.which("cmake")
     if cmake_path is not None:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,28 @@
+import platform
+
+import pytest
+
+from scikit_build_core.builder.macos import get_macosx_deployment_target
+
+
+@pytest.mark.parametrize(
+    "pycom,envvar,answer",
+    [
+        pytest.param("12.5.2", None, "12.0", id="only_plat_round"),
+        pytest.param("10.12.2", None, "10.12", id="only_plat_classic"),
+        pytest.param("11.2.2", "10.14", "11.0", id="env_var_lower"),
+        pytest.param("10.12.2", "10.13", "10.13", id="env_var_higher"),
+        pytest.param("11.2.12", "11.2", "11.0", id="same_vars_round"),
+        pytest.param("10.13.2", "11", "11.0", id="env_var_no_dot"),
+        pytest.param("11.2.12", "random", "11.0", id="invalid_env_var"),
+        pytest.param("11.2.12", "rand.om", "11.0", id="invalid_env_var_with_dot"),
+    ],
+)
+def test_macos_version(monkeypatch, pycom, envvar, answer):
+    monkeypatch.setattr(platform, "mac_ver", lambda: (pycom,))
+    if envvar is None:
+        monkeypatch.delenv("MACOSX_DEPLOYMENT_TARGET", raising=False)
+    else:
+        monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", envvar)
+
+    assert get_macosx_deployment_target() == answer

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -52,9 +52,9 @@ def test_init_cache(fp, tmp_path):
     assert (
         cmake_init.read_text()
         == f"""\
-set(SKBUILD "ON" CACHE BOOL "")
-set(SKBUILD_VERSION "1.0.0" CACHE STRING "")
-set(SKBUILD_PATH "{config.source_dir}" CACHE PATH "")
+set(SKBUILD ON CACHE BOOL "")
+set(SKBUILD_VERSION [===[1.0.0]===] CACHE STRING "")
+set(SKBUILD_PATH [===[{config.source_dir}]===] CACHE PATH "")
 """
     )
 

--- a/tests/test_simple_pure.py
+++ b/tests/test_simple_pure.py
@@ -75,7 +75,7 @@ def test_variable_defined(tmp_path, capfd):
         build_dir=build_dir,
     )
     config.init_cache({"SKBUILD": True})
-    config.configure({"SKBUILD2": True})
+    config.configure(defines={"SKBUILD2": True})
 
     out = capfd.readouterr().out
     assert "SKBUILD is defined to ON" in out


### PR DESCRIPTION
Pulling out interesting changes from #15.

- chore: better gitignore
- chore: ignore package test naming
- fix: better logger message if detached
- chore: nicer ignore (from refurb)
- feat: verbose option, use defines
- fix: properly escape in CMake
- fix: support existing folders for the build dir
- feat: macOS version computation
